### PR TITLE
feat: load components name based on repository the CLI is run in

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,21 @@ This CLI is a think wrapper around [the `changesets` CLI](https://github.com/cha
 
 Depending on in which repository the CLI is run, it will either suggest a module from [primer/react](https://github.com/primer/react) or [primer/view_components](https://github.com/primer/view_components).
 
-Run with
+## Setup for `primer/*` repository
+
+Install `primer-changesets-cli` as a dev dependency in your project. Remove `@changesets/cli` if it is already installed.
 
 ```
-npx primer-changesets-cli@latest
+npm uninstall @changesets/cli
+npm install primer-changesets-cli --save-dev
+```
+
+## Usage
+
+The usage remains the same as with `@changesets/cli`, the binary name is the same:
+
+```
+npx changeset
 ```
 
 ## How it works

--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ The usage remains the same as with `@changesets/cli`, the binary name is the sam
 npx changeset
 ```
 
+## Updating the patch
+
+1. Make your changes directly in `node_modules/@changesets/cli/dist/cli.cjs.dev.js`
+2. Run `npm run update-patch`
+
+In order to test the change locally, replace the version of `primer-changesets-cli` in the `primer/*` folder's `package.json` file
+with a local path
+
+```diff
+-    "primer-changesets-cli": "2.0.0",
++    "primer-changesets-cli": "file:../../gr2m/primer-changesets-cli",
+```
+
+Then run `npx changeset` as usual.
+
 ## How it works
 
 Unfortunately the the `@changeset/cli` package is not decomposable, we cannot easily import selected modules from it, inject our additional question, and then compose it together again before running it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,8 @@
       "version": "0.0.0-local-development",
       "hasInstallScript": true,
       "license": "ISC",
-      "dependencies": {
-        "@primer/component-metadata": "^0.5.1"
-      },
       "bin": {
-        "primer-changesets": "bin.js"
+        "changeset": "bin.js"
       },
       "devDependencies": {
         "@changesets/cli": "2.26.1",
@@ -389,11 +386,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/@primer/component-metadata": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@primer/component-metadata/-/component-metadata-0.5.1.tgz",
-      "integrity": "sha512-+3tuJScHWRifOAyMV+cn1I533j+PcprvPXbKnH1W7N+vhaGyaaHTao8Dkyyhxbhklmumcf8XR+Lz6dK1ojDrCg=="
     },
     "node_modules/@types/is-ci": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -7,14 +7,12 @@
   },
   "scripts": {
     "postinstall": "patch-package",
-    "prepublishOnly": "cp node_modules/@changesets/cli/dist/cli.cjs.dev.js bin.js && sed -i '1s/^/#!\\/usr\\/bin\\/env node\\n\\n/' bin.js"
+    "prepublishOnly": "cp node_modules/@changesets/cli/dist/cli.cjs.dev.js bin.js && sed -i '1s/^/#!\\/usr\\/bin\\/env node\\n\\n/' bin.js",
+    "update-patch": "npx patch-package @changesets/cli"
   },
   "author": "Gregor Martynus (https://github.com/gr2m)",
   "license": "ISC",
   "repository": "github:gr2m/primer-changesets-cli",
-  "dependencies": {
-    "@primer/component-metadata": "^0.5.1"
-  },
   "devDependencies": {
     "@changesets/cli": "2.26.1",
     "patch-package": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-local-development",
   "description": "The Primer flavored changesets CLI",
   "bin": {
-    "primer-changesets": "bin.js"
+    "changeset": "bin.js"
   },
   "scripts": {
     "postinstall": "patch-package",

--- a/patches/@changesets+cli+2.26.1.patch
+++ b/patches/@changesets+cli+2.26.1.patch
@@ -1,26 +1,94 @@
 diff --git a/node_modules/@changesets/cli/dist/cli.cjs.dev.js b/node_modules/@changesets/cli/dist/cli.cjs.dev.js
-index 73ab02a..699305d 100644
+index 73ab02a..56d1703 100644
 --- a/node_modules/@changesets/cli/dist/cli.cjs.dev.js
 +++ b/node_modules/@changesets/cli/dist/cli.cjs.dev.js
-@@ -458,9 +458,17 @@ async function createChangeset(changedPackages, allPackages) {
+@@ -335,6 +335,62 @@ function formatPkgNameAndVersion(pkgName, version) {
+ async function createChangeset(changedPackages, allPackages) {
+   const releases = [];
+ 
++// PATCH: verify that CLI is run in a supported repository
++  const SUPPORTED_PRIMER_PACKAGES = [
++    "@primer/react",
++    "@primer/view-components",
++  ];
++  const pkgPath = require(path__default["default"].join(
++    process.cwd(),
++    "package.json"
++  ));
++  let pkg;
++  try {
++    pkg = require(path__default["default"].join(process.cwd(), "package.json"));
++  } catch {
++    throw new Error(
++      `This CLI must be run in a Primer package repository. No package.json found at ${pkgPath}`
++    );
++  }
++
++  const primerPackages = [];
++
++  if (pkg.name === "@primer/react") {
++    const componentsPath = path__default["default"].join(
++      process.cwd(),
++      "generated/components.json"
++    );
++    logger.log(
++      `Loading components information for ${pkg.name} from ${componentsPath}`
++    );
++    const { components } = require(componentsPath);
++    primerPackages.push(
++      ...Object.values(components).map((component) => component.name)
++    );
++  } else if (pkg.name === "@primer/view-components") {
++    logger.log(
++      `Loading components information for ${pkg.name} from https://primer.github.io/view_components/components.json`
++    );
++
++    if (!globalThis?.fetch) {
++      throw new Error(`This CLI must be run in a Node.js 18+`);
++    }
++
++    const response = await fetch(
++      "https://primer.github.io/view_components/components.json"
++    );
++    const components = await response.json();
++    primerPackages.push(...components.map((component) => component.id));
++  } else {
++    if (!SUPPORTED_PRIMER_PACKAGES.includes(pkg.name)) {
++      throw new Error(
++        `This CLI is only supported in the following packages: ${SUPPORTED_PRIMER_PACKAGES.join(
++          ", "
++        )}`
++      );
++    }
++  }
++
+   if (allPackages.length > 1) {
+     const packagesToRelease = await getPackagesToRelease(changedPackages, allPackages);
+     let pkgJsonsByName = getPkgJsonsByName(allPackages);
+@@ -458,10 +514,21 @@ async function createChangeset(changedPackages, allPackages) {
      }
    }
  
-+  logger.log(chalk__default['default'].gray("  (select packages with <space>, type to filter, confirm with <enter>)"));
-+  const { components } = require("@primer/component-metadata")
-+  const primerPackages = await askCheckboxPlus(
-+    `Which Primer packages have been affected by this change?`, 
-+    Object.keys(components),
-+  )
++  logger.log(
++    chalk__default["default"].gray(
++      "  (select packages with <space>, type to filter, confirm with <enter>)"
++    )
++  );
++  const selectedPrimerPackages = await askCheckboxPlus(
++    `Which Primer packages have been affected by this change?`,
++    primerPackages
++  );
 +
    return {
      confirmed: false,
      summary,
-+    primerPackages,
-     releases
+-    releases
++    selectedPrimerPackages,
++    releases,
    };
  }
-@@ -531,7 +539,8 @@ async function add(cwd, {
+ 
+@@ -531,7 +598,8 @@ async function add(cwd, {
      });
      const changedPackagesName = changedPackages.filter(pkg => isListablePackage(config, pkg.packageJson)).map(pkg => pkg.packageJson.name);
      newChangeset = await createChangeset(changedPackagesName, listablePackages);
@@ -30,7 +98,7 @@ index 73ab02a..699305d 100644
  
      if (!newChangeset.confirmed) {
        newChangeset = _objectSpread2(_objectSpread2({}, newChangeset), {}, {
-@@ -542,6 +551,15 @@ async function add(cwd, {
+@@ -542,6 +610,15 @@ async function add(cwd, {
  
    if (newChangeset.confirmed) {
      const changesetID = await writeChangeset__default['default'](newChangeset, cwd);
@@ -39,14 +107,14 @@ index 73ab02a..699305d 100644
 +    const changesetPath = path__default['default'].resolve(changesetBase, `${changesetID}.md`);
 +    let content = await fs__default['default'].readFile(changesetPath, 'utf8')
 +
-+    content += `\nChanged components: ${newChangeset.primerPackages.join(", ")}\n`
++    content += `\nChanged components: ${newChangeset.selectedPrimerPackages.join(", ")}\n`
 +
 +    await fs__default['default'].writeFile(changesetPath, content)
 +
      const [{
        getAddMessage
      }, commitOpts] = getCommitFunctions(config.commit, cwd);
-@@ -565,7 +583,7 @@ async function add(cwd, {
+@@ -565,7 +642,7 @@ async function add(cwd, {
        logger.log(chalk__default['default'].green("If you want to modify or expand on the changeset summary, you can find it here"));
      }
  
@@ -55,7 +123,7 @@ index 73ab02a..699305d 100644
      logger.info(chalk__default['default'].blue(changesetPath));
  
      if (open) {
-@@ -1565,7 +1583,9 @@ const {
+@@ -1565,7 +1642,9 @@ const {
  
    }
  });


### PR DESCRIPTION
BREAKING CHANGE: the modules binary has been renamed from `primer-changesets` to `changeset` in order to work as a drop-in replacement for `@changeset/cli`
